### PR TITLE
feat: allow static values to be set on object

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ Defaults to `https://players.brightcove.net/{accountId}/{playerId}_{embedId}/ind
 
 `excludeTags` - array of tags to not include as keywords, e.g. `["youtubesync"]`
 
+`baseObject` - an option object of properties onto which to build the video specific metadata. For example this could be used to include a publisher object:
+
+```json
+"baseObject": {
+  "publisher": {
+    "@type": "Organization",
+    "name": "Publisher name",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.jpg",
+      "width": 600,
+      "height": 60
+    }
+  }
+}
+```
+
 ## Install
 
 Add [as a plugin to a player in Video Cloud Studio][plugins]:

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,7 +7,8 @@ import duration8601 from './duration';
 const defaults = {
   schemaId: 'https://players.brightcove.net/{accountId}/{playerId}_{embedId}/index.html?videoId={id}',
   keywords: false,
-  excludeTags: []
+  excludeTags: [],
+  baseObject: {}
 };
 
 /**
@@ -37,7 +38,7 @@ const schema = function(options) {
       return;
     }
 
-    const ld = {
+    const ld = videojs.mergeOptions(options.baseObject, {
       '@context': 'http://schema.org/',
       '@type': 'VideoObject',
       'name': this.mediainfo.name,
@@ -51,7 +52,7 @@ const schema = function(options) {
         .replace('{playerId}', this.bcinfo.playerId)
         .replace('{embedId}', this.bcinfo.embedId)
         .replace('{accountId}', this.bcinfo.accountId)
-    };
+    });
 
     const formattedDuration = duration8601(this.mediainfo.duration);
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -190,3 +190,20 @@ QUnit.test('includes tags if requested', function(assert) {
 
   assert.strictEqual(generatedSchema.keywords, 'one,three', 'add tags except exclusions');
 });
+
+QUnit.test('merges onto base options', function(assert) {
+
+  this.player.schema({
+    baseObject: {
+      param1: 'abc'
+    }
+  });
+  this.player.trigger('error');
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  const generatedSchema = JSON.parse(this.player.schemaEl_.textContent);
+
+  assert.strictEqual(generatedSchema.param1, 'abc', 'merged onto base options');
+});


### PR DESCRIPTION
On [one of Google's pages on schema](https://developers.google.com/search/docs/data-types/article), publisher is required. Allow static data to be added to the final json.