### PR TITLE
feat: add option to use long description

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Defaults to `https://players.brightcove.net/{accountId}/{playerId}_{embedId}/ind
 }
 ```
 
+`preferLongDescription` - if `true`, use the long description if available. If `false`, or `true` and long description is not set then the (short) description field will be used. Default is `false`.
+
 ## Install
 
 Add [as a plugin to a player in Video Cloud Studio][plugins]:

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,7 +8,8 @@ const defaults = {
   schemaId: 'https://players.brightcove.net/{accountId}/{playerId}_{embedId}/index.html?videoId={id}',
   keywords: false,
   excludeTags: [],
-  baseObject: {}
+  baseObject: {},
+  preferLongDescription: false
 };
 
 /**
@@ -21,6 +22,14 @@ const defaults = {
  *           An object of options
  * @param    {string} [options.schemaId]
  *           A URI to use as the id in the schema
+ * @param    {boolean} [options.keywords]
+ *           Whether to include tags as keywords
+ * @param    {Array} [options.excludeTags]
+ *           If including tags, an array of tags to exclude
+ * @param    {Object} [options.baseObject]
+ *           A template object to build the schema onto
+ * @param    {boolean} [options.preferLongDescription]
+ *           Whether to prefer the long description
  */
 const schema = function(options) {
   // Add element for this player to DOM
@@ -42,7 +51,6 @@ const schema = function(options) {
       '@context': 'http://schema.org/',
       '@type': 'VideoObject',
       'name': this.mediainfo.name,
-      'description': this.mediainfo.description,
       'thumbnailUrl': this.mediainfo.poster,
       'uploadDate': this.mediainfo.publishedAt.split('T')[0],
       // Poor man's ad macros
@@ -53,6 +61,12 @@ const schema = function(options) {
         .replace('{embedId}', this.bcinfo.embedId)
         .replace('{accountId}', this.bcinfo.accountId)
     });
+
+    if (options.preferLongDescription) {
+      ld.description = this.mediainfo.longDescription || this.mediainfo.description;
+    } else {
+      ld.description = this.mediainfo.description;
+    }
 
     const formattedDuration = duration8601(this.mediainfo.duration);
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -42,7 +42,8 @@ QUnit.module('videojs-schema', {
       duration: 3661,
       publishedAt: '2019-02-12T09:07:44',
       poster: 'https://loremflickr.com/1280/720',
-      tags: ['one', 'two', 'three']
+      tags: ['one', 'two', 'three'],
+      longDescription: 'LONGDESCRIPTION'
     };
   },
 
@@ -206,4 +207,32 @@ QUnit.test('merges onto base options', function(assert) {
   const generatedSchema = JSON.parse(this.player.schemaEl_.textContent);
 
   assert.strictEqual(generatedSchema.param1, 'abc', 'merged onto base options');
+});
+
+QUnit.test('defaults to short description', function(assert) {
+
+  this.player.schema();
+  this.player.trigger('error');
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  const generatedSchema = JSON.parse(this.player.schemaEl_.textContent);
+
+  assert.strictEqual(generatedSchema.description, 'DESCRIPTION', 'used short description');
+});
+
+QUnit.test('long description can be used', function(assert) {
+
+  this.player.schema({
+    preferLongDescription: true
+  });
+  this.player.trigger('error');
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  const generatedSchema = JSON.parse(this.player.schemaEl_.textContent);
+
+  assert.strictEqual(generatedSchema.description, 'LONGDESCRIPTION', 'used long description');
 });


### PR DESCRIPTION
If `preferLongDescription` is `true`, use the video's long description if it has one. Defaults to `false`