### PR TITLE
fix: Use full 8601 datetime for uploadDate

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         name: 'NAME',
         description: 'DESCRIPTION',
         duration: 150,
-        publishedAt: '2019-02-12T09:07:44',
+        publishedAt: '2019-02-12T09:07:44Z',
         poster: 'https://loremflickr.com/1280/720',
         textTracks: [{
           "src": trackSrc,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -65,8 +65,8 @@ const schema = function(options) {
       '@type': 'VideoObject',
       'name': mediainfo.name,
       'thumbnailUrl': mediainfo.poster,
-      'uploadDate': mediainfo.publishedAt.split('T')[0],
-      // Poor man's ad macros
+      'uploadDate': mediainfo.publishedAt,
+      // Subset of videojs-contrib-ads macros
       '@id': options.schemaId
         .replace('{id}', mediainfo.id)
         .replace('{referenceId}', mediainfo.referenceId)


### PR DESCRIPTION
Google previously wanted or at least accepted just a date for `publishedAt`, now it shows a warning if it's not an 8601 datetime including timezone. This is what is output from the playback API in any case, so just use the string unmodified.